### PR TITLE
Change language model at runtime + specify audio source

### DIFF
--- a/demo/robocup_r1.launch
+++ b/demo/robocup_r1.launch
@@ -1,0 +1,7 @@
+<launch>
+	<node name="recognizer_1" pkg="pocketsphinx" type="recognizer.py" output="screen">
+		<param name="mic_name" value="alsa_input.usb-Logitech_Logitech_Wireless_Headset-00-Headset.analog-mono"/>
+		<param name="lm" value="$(find pocketsphinx)/demo/robocup.lm"/>
+		<param name="dict" value="$(find pocketsphinx)/demo/robocup.dic"/>
+	</node>
+</launch>

--- a/demo/robocup_r2.launch
+++ b/demo/robocup_r2.launch
@@ -1,0 +1,7 @@
+<launch>
+	<node name="recognizer_2" pkg="pocketsphinx" type="recognizer.py" output="screen">
+		<param name="mic_name" value="alsa_input.usb-Logitech_Logitech_G35_Headset-00-Headset_1.analog-mono"/>
+		<param name="lm" value="$(find pocketsphinx)/demo/robocup.lm"/>
+		<param name="dict" value="$(find pocketsphinx)/demo/robocup.dic"/>
+	</node>
+</launch>


### PR DESCRIPTION
- Changing the language model at runtime will update what language model is used by the recognizer because the lm/dic parameters are reloaded when the ~start service is called.
- A specific audio source can be connected to by specifying the name of the device in the launch file. This is useful when you want to have multiple audio sources each processed by independent recognizers.
